### PR TITLE
This PR will make le frogfood compile and run again on ze linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,4 +140,6 @@ target_compile_definitions(glm INTERFACE GLM_FORCE_DEPTH_ZERO_TO_ONE VK_NO_PROTO
 
 if (MSVC)
     target_compile_definitions(frogRender PUBLIC STBI_MSC_SECURE_CRT)
+else()
+    target_link_libraries(frogRender PRIVATE tbb)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 
+set(CMAKE_WARN_DEPRECATED OFF CACHE BOOL "")
+
 project(Frogfood)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -73,7 +73,7 @@ set(VMA_DYNAMIC_VULKAN_FUNCTIONS OFF CACHE BOOL "" FORCE)
 FetchContent_Declare(
     vma
     GIT_REPOSITORY https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator
-    GIT_TAG        v3.0.1
+    GIT_TAG        v3.1.0
     SYSTEM
 )
 

--- a/src/Fvog/Shader2.h
+++ b/src/Fvog/Shader2.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 #include <filesystem>
+#include <vector>
 #include "BasicTypes2.h"
 
 namespace Fvog

--- a/src/ImGui/imgui_impl_fvog.cpp
+++ b/src/ImGui/imgui_impl_fvog.cpp
@@ -534,7 +534,7 @@ static void ImGui_ImplFvog_CreateShaderModules(VkDevice device)
   }
 }
 
-static [[nodiscard]] Fvog::GraphicsPipeline ImGui_ImplFvog_CreatePipeline(VkDevice device, VkSampleCountFlagBits MSAASamples)
+[[nodiscard]] static Fvog::GraphicsPipeline ImGui_ImplFvog_CreatePipeline(VkDevice device, VkSampleCountFlagBits MSAASamples)
 {
   ImGui_ImplFvog_Data* bd = ImGui_ImplFvog_GetBackendData();
   ImGui_ImplFvog_CreateShaderModules(device);


### PR DESCRIPTION
Updated Vma to latest release from May.
Suppress depreciation messages when CMake does its thing
I also snuck the tbb stuff into an existing `if (MSVC)`
The rest was a missing include and [[nodiscard]] comes before any modifiers